### PR TITLE
Fix seeding in data generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ git clone https://github.com/Nero911-novice/my-streamlit-app.git
 cd my-streamlit-app
 pip install -r requirements.txt
 streamlit run streamlit_app.py
+```
 
-
+После запуска откройте приложение по адресу `http://localhost:8501`.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,9 +14,14 @@ st.set_page_config(page_title="Демоверсия вероятностных �
 
 # --- Кэшированные функции для генерации данных ---
 @st.cache_data
-def generate_distribution_data(dist_type: str, size: int, **params) -> np.ndarray:
-    """Универсальная функция для генерации данных различных распределений с кэшированием"""
-    np.random.seed(42)  # Для воспроизводимости
+def generate_distribution_data(dist_type: str, size: int, seed: Optional[int] = None, **params) -> np.ndarray:
+    """Универсальная функция для генерации данных различных распределений с кэшированием.
+
+    Если передан seed, используется фиксированное значение для воспроизводимости,
+    иначе данные генерируются с текущим состоянием генератора случайных чисел.
+    """
+    if seed is not None:
+        np.random.seed(seed)
     
     distributions = {
         "Нормальное": lambda: np.random.normal(params.get('mu', 0), params.get('sigma', 1), size),
@@ -800,12 +805,15 @@ def regression_to_mean_tab():
     """)
 
 @st.cache_data
-def generate_regression_data(mu_reg: int, sigma_reg: int, n_subjects: int, 
-                           threshold_percentile: int) -> Optional[Tuple]:
-    """Генерация данных для демонстрации регрессии к среднему"""
+def generate_regression_data(mu_reg: int, sigma_reg: int, n_subjects: int,
+                           threshold_percentile: int, seed: Optional[int] = None) -> Optional[Tuple]:
+    """Генерация данных для демонстрации регрессии к среднему.
+
+    Если задан seed, данные будут воспроизводимыми, иначе используются случайные значения.
+    """
     try:
-        # Фиксируем seed для воспроизводимости
-        np.random.seed(42)
+        if seed is not None:
+            np.random.seed(seed)
         
         # Истинные способности
         true_abilities = np.random.normal(mu_reg, sigma_reg/2, n_subjects)


### PR DESCRIPTION
## Summary
- add optional `seed` argument to `generate_distribution_data`
- add optional `seed` argument to `generate_regression_data`
- fix README code block

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_683fcf29ec2083279edef52a13d7e5c6