### PR TITLE
Add time import to CLT tab

### DIFF
--- a/app_tabs/central_limit.py
+++ b/app_tabs/central_limit.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import numpy as np
+import time
 import matplotlib.pyplot as plt
 import seaborn as sns
 from .utils import calculate_sample_means, create_download_button


### PR DESCRIPTION
## Summary
- add missing `time` import to Central Limit Theorem tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68400150a3408327bc94449574cd9ea6